### PR TITLE
Init v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # CornGame
 Corn Maze game written in rust with the bevy engine
 
-Currently implemented:
-  basic application structure
-  dynamic creation of corn field instance data on the gpu
-Todo:
-  dynamically merge all corn instance data buffers into one master buffer
-  Frustum culling, and LOD grouping
-  Actually render the corn
-  Custom shadow mapping
-  Some sort of extreme distance billboarding technique
-  actual game logic
+## TODO:
+- [x] basic application structure
+- [x] dynamic creation of corn field instance data on the gpu
+- [x] dynamically merge all corn instance data buffers into one master buffer
+- [ ] Frustum culling, and LOD grouping
+- [ ] Actually render the corn
+- [ ] Custom shadow mapping
+- [ ] Some sort of extreme distance billboarding technique
+- [ ] actual game logic

--- a/assets/shaders/corn_init.wgsl
+++ b/assets/shaders/corn_init.wgsl
@@ -1,16 +1,29 @@
 struct PerCornData {
-  offset_scale: vec4<f32>,
-  rotation: vec4<f32>
+  offset: vec3<f32>,
+  scale: f32,
+  rotation: vec2<f32>,
+  uuid: u32,
+  empty: u32
 }
-@group(0) @binding(0)
-var<storage,read_write> instance_data: array<PerCornData>;
-struct Settings {
+struct Range {
+  start: u32,
+  length: u32,
+  id: u32,
+  offset: u32
+}
+struct CornSettings {
   origin: vec3<f32>,
-  height: vec2<f32>,
+  height_width_min: vec2<f32>,
   step: vec2<f32>,
   res_width: u32
 }
-var<push_constant> settings: Settings;
+@group(0) @binding(0)
+var<storage,read_write> instance_data: array<PerCornData>;
+@group(0) @binding(1)
+var<storage, read> ranges: array<Range>;
+@group(0) @binding(2)
+var<uniform> settings: array<CornSettings, 32>;
+var<push_constant> range_count: vec4<u32>;
 
 fn hash(value: u32) -> u32 {
     var state = value;
@@ -27,15 +40,25 @@ fn randomFloat(value: u32) -> f32 {
     return f32(hash(value)) / 4294967295.0;
 }
 
-@compute @workgroup_size(16, 16, 1)
+@compute @workgroup_size(256, 1)
 fn init(@builtin(global_invocation_id) gid: vec3<u32>, @builtin(num_workgroups) id_count: vec3<u32>) {
-  let lid: u32 = gid.x + gid.y * (16u*id_count.x);
-  let pos: vec2<f32> = vec2<f32>(f32(lid%settings.res_width), f32(lid/settings.res_width));
-  var world_pos: vec4<f32> = vec4<f32>(settings.origin, 0.0);
-  world_pos.x += settings.origin.x*settings.step.x;
-  world_pos.y += settings.origin.y*settings.step.y;
-  world_pos.w = randomFloat(lid) * (settings.height.y - settings.height.x) + settings.height.x;
-  let theta = randomFloat(lid+id_count.x*id_count.y*16u*16u)*6.2832;
-  let rotation: vec4<f32> = vec4<f32>(sin(theta), cos(theta), 0.0, 0.0);
-  instance_data[lid] = PerCornData(world_pos, rotation);
+  var index: vec2<u32> = vec2<u32>(0u, 0u);
+  var location: u32 = 0u;
+  for (var i = 0u; i < range_count.x; i++){
+    let new_location = location+ranges[i].length;
+    index += vec2<u32>(i, location)*u32(location>=gid.x)*u32(gid.x<new_location);
+    location = new_location;
+  }
+  let range = ranges[index.x];
+  let buffer_index: u32 = gid.x - index.y + range.start;
+  let instance_index: u32 = buffer_index - range.start + range.offset;
+  let instance_settings = settings[range.id];
+  let pos: vec2<f32> = vec2<f32>(f32(instance_index%instance_settings.res_width), f32(instance_index/instance_settings.res_width));
+  var out: PerCornData;
+  out.offset = instance_settings.origin + vec3<f32>(pos*instance_settings.step, 0.0);
+  out.scale = randomFloat(gid.x) * instance_settings.height_width_min.x + instance_settings.height_width_min.y;
+  let theta = randomFloat(gid.x+256u*id_count.x)*6.2832;
+  out.rotation = vec2<f32>(sin(theta), cos(theta));
+  out.uuid = 1u<<range.id;
+  instance_data[buffer_index] = out;
 }

--- a/src/core/loading/setup_scene_plugin.rs
+++ b/src/core/loading/setup_scene_plugin.rs
@@ -61,10 +61,8 @@ fn setup_scene(
         transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     }, FlyCam));
-
-    //Spawn Corn
+    //Spawn Corn Field
     commands.spawn((
-        meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
         SpatialBundle::INHERITED_IDENTITY,
         CornField::new(
             Vec3::ZERO, 
@@ -74,7 +72,6 @@ fn setup_scene(
         ),
         NoFrustumCulling
     ));
-
     //Spawn Rest of Scene
     //box
     commands.spawn(PbrBundle{

--- a/src/ecs/corn_field/mod.rs
+++ b/src/ecs/corn_field/mod.rs
@@ -1,42 +1,27 @@
 pub mod init;
-pub mod render;
 
-use std::mem::size_of;
+use std::{ops::Range, mem::size_of};
 use bevy::{
     prelude::*,
     render::{
-        extract_component::ExtractComponent,
         render_resource::*,
-    }, utils::hashbrown::HashMap
+        renderer::{RenderDevice, RenderContext}, 
+        extract_component::ExtractComponent,
+    }, utils::hashbrown::HashMap, math::bool
 };
 use bytemuck::{Pod, Zeroable};
-use self::init::{CornFieldDataState, CornFieldInitPlugin};
+use self::init::*;
 
-/// Per Instance Corn Data
-/// contains the offset from the position of the corn field entity
-/// the scale is tacked onto the end of the offset_scale vector
-/// the rotation takes up the first 2 values of the rotation vector (sin and cos of the angle)
-/// the struct has to be a multiple of 16 bytes long due to storage buffer limitations
-#[derive(Clone, Copy, Pod, Zeroable, Debug)]
+#[derive(Clone, Copy, Pod, Zeroable, Debug, ShaderType)]
 #[repr(C)]
 pub struct PerCornData{
-    offset_scale: Vec4,
-    rotation: Vec4
+    offset: Vec3,
+    scale: f32,
+    rotation: Vec2,
+    uuid: u32, //32 possible uuids, one per bit for use in a bitmask
+    empty: u32
 }
 
-/// Component that stores the instance data of a corn field
-/// Added to corn field entities after the gpu initializes the data
-/// only if RenderedCornFields.read_back_data is true
-#[derive(Component)]
-pub struct CornInstanceData{
-    data: Vec<PerCornData>
-}
-
-/// The component representing a corn field
-/// center is the position of the corn field's center relative to the entities world position
-/// half_extents is the width and length of the corn field in world units
-/// resolution is the number of corn stalks along the width and length
-/// height_range is the min-max range of height scalars to randomize the corn with
 #[derive(Component, ExtractComponent, Clone, Debug)]
 pub struct CornField{
     center: Vec3,
@@ -56,36 +41,226 @@ impl CornField{
     }
 }
 
-/// Resource to store all of the corn fields and their data in the RenderApp
-#[derive(Resource)]
+#[derive(Resource, Default)]
 pub struct RenderedCornFields{
-    fields: HashMap<Entity, CornFieldRenderData>,
-    read_back_data: bool
+    pub buffer: DynamicInstanceBuffer,
+    pub data: HashMap<Entity, CornFieldRenderData>,
+    pub settings: CornInitShaderData
 }
-impl Default for RenderedCornFields{
-    fn default() -> Self {
-        Self{fields: HashMap::new(), read_back_data: false}
+impl RenderedCornFields{
+    pub fn init_buffer(&mut self, render_device: &RenderDevice) {
+        if self.buffer.is_initialized(){return;}
+        self.buffer.init(
+            render_device, 
+            "Corn Instance Buffer", 
+            1000000, 
+            size_of::<PerCornData>(), 
+            BufferUsages::STORAGE | BufferUsages::VERTEX
+        );
+    }
+    pub fn add_data(&mut self, entity: Entity, corn_field: &CornField){
+        let new_data = CornFieldRenderData::new(
+            corn_field.center, 
+            corn_field.half_extents, 
+            corn_field.resolution, 
+            corn_field.height_range
+        );
+        if let Some(old_data) = self.data.insert(entity, new_data){
+            self.buffer.add_ranges(&old_data.ranges);
+            self.buffer.add_id(old_data.id.unwrap());
+        }
+    }
+    pub fn record_stale_data(&mut self, real_entities: &Vec<Entity>){
+        self.data.iter_mut()
+            .filter(|(k, _)| !real_entities.contains(*k))
+            .for_each(|(_, v)| 
+        {
+            v.state = CornFieldDataState::Stale;
+        });
+    }
+    pub fn remove_stale_data_and_update_state(&mut self){
+        self.data.retain(|_, data| {
+            if data.state == CornFieldDataState::Stale{
+                if let Some(id) = data.id{
+                    self.buffer.add_id(id);
+                }
+                self.buffer.add_ranges(&data.ranges);
+                return false;
+            }else if data.state == CornFieldDataState::Loading{
+                data.state = CornFieldDataState::Loaded;
+            }
+            return true;
+        });
+    }
+    pub fn init_new_data(&mut self) {
+        self.data.iter_mut().filter(|(_, v)| v.state == CornFieldDataState::Unloaded)
+            .for_each(|(_, data)| 
+        {
+            data.id = self.buffer.get_id();
+            if data.id.is_none() {return;}
+            data.ranges = self.buffer.get_ranges(data.get_instance_count());
+            data.state = CornFieldDataState::Loading;
+            self.settings.run_init_pass = true;
+        });
+    }
+    pub fn create_settings(&mut self) -> (ComputeSettingsVector, Vec<ComputeRange>, usize){
+        let mut settings_vec = ComputeSettingsVector { 
+            array: [ComputeSettings::default(); 32] 
+        };
+        let mut ranges: Vec<ComputeRange> = vec![];
+        let mut total_corn: usize = 0;
+        self.data.iter().filter(|(_, v)| v.state == CornFieldDataState::Loading)
+            .for_each(|(_, v)| 
+        {
+            settings_vec.array[v.id.unwrap() as usize] = ComputeSettings::from(v);
+            total_corn += v.ranges.count();
+            ranges.extend(v.ranges.convert_to_compute_vec(v.id.unwrap()));
+        });
+        return (settings_vec, ranges, total_corn);
+    }
+    pub fn create_bind_group(&mut self, render_device: &RenderDevice, layout: &BindGroupLayout){
+        let mut bind_group_entries = [
+            BindGroupEntry{
+                binding: 0,
+                resource: self.buffer.buffer.as_ref().unwrap().as_entire_binding()
+            },
+            BindGroupEntry{
+                binding: 1,
+                resource: self.settings.range_buffer.binding().unwrap()
+            },
+            BindGroupEntry{
+                binding: 2,
+                resource: self.settings.settings_buffer.binding().unwrap()
+            }
+        ];
+        if self.buffer.needs_to_expand {
+            bind_group_entries[0] = BindGroupEntry{binding: 0, resource: self.buffer.temp_buffer.as_ref().unwrap().as_entire_binding()}
+        }
+        self.settings.bind_group = Some(render_device.create_bind_group(&BindGroupDescriptor { 
+            label: Some("Corn Init Buffer Bind Group"), 
+            layout, 
+            entries: &bind_group_entries
+        }));
+    }
+    pub fn run_init(&self, render_context: &mut RenderContext, world: &World){
+        if !self.settings.run_init_pass {return;}
+        //get pipelines
+        let pipeline_cache = world.resource::<PipelineCache>();
+        let pipeline = world.resource::<InitCornBuffersPipeline>();
+        //find our compute pipeline
+        let compute_pipeline = pipeline_cache.get_compute_pipeline(pipeline.id);
+        if compute_pipeline.is_none() {return;}
+        let compute_pipeline = compute_pipeline.unwrap();
+        //create compute pass
+        let mut compute_pass = render_context.command_encoder()
+            .begin_compute_pass(&ComputePassDescriptor {label: Some("Initialize Corn Data Pass") });
+        compute_pass.set_pipeline(&compute_pipeline);
+        //Set shader inputs
+        compute_pass.set_bind_group(0, self.settings.bind_group.as_ref().unwrap(), &[]);
+        compute_pass.set_push_constants(0, bytemuck::cast_slice(&[self.settings.range_count as u32, 0, 0, 0]));
+        compute_pass.dispatch_workgroups((self.settings.corn_count as f32 / 256.0).ceil() as u32, 1, 1);
     }
 }
 
-/// Stores the renderapp data for a single corn field.
-/// This includes corn field settings present on a corn field component,
-/// the buffers used to store the data, and its current state
-/// in the loading process
+pub struct DynamicInstanceBuffer{
+    buffer: Option<Buffer>,
+    ranges: Vec<Range<u32>>,
+    ids: Vec<u32>,
+    temp_buffer: Option<Buffer>,
+    size: usize,
+    old_size: Option<usize>,
+    needs_to_expand: bool
+}
+impl Default for DynamicInstanceBuffer{
+    fn default() -> Self {
+        Self{buffer: None, ranges: vec![], ids: vec![], temp_buffer: None, size: 0, old_size: None, needs_to_expand: false}
+    }
+}
+impl DynamicInstanceBuffer{
+    pub fn init(&mut self, render_device: &RenderDevice, name: &str, count: u64, stride_length: usize, usages: BufferUsages){
+        self.buffer = Some(render_device.create_buffer(&BufferDescriptor{ 
+            label: Some(name), 
+            size: count * stride_length as u64, 
+            usage: usages | BufferUsages::COPY_DST | BufferUsages::COPY_SRC, 
+            mapped_at_creation: false
+        }));
+        self.ids = (0..32).collect();
+        self.ranges = vec![(0..count as u32)];
+        self.size = count as usize;
+    }
+    pub fn add_ranges(&mut self, ranges: &Vec<Range<u32>>){
+        self.ranges.combine(ranges);
+    }
+    pub fn add_id(&mut self, id: u32){
+        self.ids.push(id);
+    }
+    pub fn finish_previous_frame_expansion(&mut self) {
+        if self.needs_to_expand{
+            self.buffer.as_mut().unwrap().destroy();
+            self.buffer = self.temp_buffer.take();
+            self.needs_to_expand = false;
+            self.old_size = None;
+        }
+    }
+    pub fn is_initialized(&self) -> bool {return self.buffer.is_some();}
+    pub fn get_id(&mut self) -> Option<u32>{return self.ids.pop();}
+    pub fn get_ranges(&mut self, count: u32) -> Vec<Range<u32>>{
+        if self.ranges.count() < count as usize{
+            self.needs_to_expand = true;
+            self.old_size.get_or_insert(self.size);
+            let start = self.size;
+            self.size += count as usize - self.ranges.count();
+            self.size += self.size/2;
+            self.ranges.insert_or_extend(start as u32..self.size as u32);
+        }
+        self.ranges.get_ranges(count)
+    }
+    pub fn init_expansion(&mut self, render_device: &RenderDevice){
+        self.temp_buffer = Some(render_device.create_buffer(&BufferDescriptor{ 
+            label: Some("Master Corn Buffer"), 
+            size: self.size as u64*size_of::<PerCornData>() as u64, 
+            usage: BufferUsages::VERTEX | BufferUsages::STORAGE | BufferUsages::COPY_SRC | BufferUsages::COPY_DST, 
+            mapped_at_creation: false
+        }));
+    }
+    pub fn run_expansion(&self, render_context: &mut RenderContext){
+        if !self.needs_to_expand || self.temp_buffer.is_none(){return;}
+        render_context.command_encoder().copy_buffer_to_buffer(
+            self.buffer.as_ref().unwrap(), 
+            0, 
+            self.temp_buffer.as_ref().unwrap(), 
+            0, 
+            self.old_size.unwrap() as u64 * size_of::<PerCornData>() as u64
+        );
+    }
+}
+
 pub struct CornFieldRenderData{
     state: CornFieldDataState,
     center: Vec3,
     half_extents: Vec2,
     resolution: (usize, usize),
     height_range: Vec2,
-    data: Option<Vec<PerCornData>>,
-    instance_buffer: Option<Buffer>,
-    instance_buffer_bind_group: Option<BindGroup>,
-    cpu_readback_buffer: Option<Buffer>
+    id: Option<u32>,
+    ranges: Vec<Range<u32>>
 }
 impl CornFieldRenderData{
-    pub fn get_byte_count(&self) -> u64{
-        return (self.resolution.0*self.resolution.1*size_of::<PerCornData>()) as u64;
+    pub fn new(center: Vec3, half_extents: Vec2, resolution: (usize, usize), height_range: Vec2) -> Self{
+        Self { 
+            state: CornFieldDataState::Unloaded, 
+            center, 
+            half_extents, 
+            resolution, 
+            height_range, 
+            id: None, 
+            ranges: vec![] 
+        }
+    }
+    pub fn get_byte_count(&self) -> u32{
+        return (self.resolution.0*self.resolution.1*size_of::<PerCornData>()) as u32;
+    }
+    pub fn get_instance_count(&self) -> u32{
+        return (self.resolution.0*self.resolution.1) as u32;
     }
 }
 
@@ -93,6 +268,8 @@ impl CornFieldRenderData{
 pub struct CornFieldComponentPlugin;
 impl Plugin for CornFieldComponentPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(CornFieldInitPlugin);
+        app
+            .add_plugins(CornFieldInitPlugin)
+            .init_resource::<RenderedCornFields>();
     }
 }


### PR DESCRIPTION
# Completely reworked the corn data flow
CornField component -> RenderedCornFields resource -> DynamicInstanceBuffer on the gpu
- All corn is stored on one dynamically sized buffer on the gpu
- stale data is not currently deleted only overwritten, but will need to at least have a flag set in the future to not render them
- the buffer is only altered when there is a change in the data on the cpu side, and is altered in the smallest way possible to save performance
- At some point, i should add a system to shrink the buffer if it is too large
- likewise, a system is also eventually needed to occasionally defragment the buffer if it gets too chaotic
- there is an optional feature to read back data from the buffer to the cpu for debugging purposes